### PR TITLE
VDT-2737 Removing database name from table statements

### DIFF
--- a/VantageCloudLakeUseCases/content/FSCustomerJourney/README.md
+++ b/VantageCloudLakeUseCases/content/FSCustomerJourney/README.md
@@ -90,7 +90,7 @@ CREATE TABLE FSCJ_marketing_attribution AS (
                 customer_identifier, interaction_timestamp, interaction_type, customer_days_active, customer_type,
                 marketing_placement, marketing_description, marketing_category,
                 interaction_type || product_category AS interaction_product
-            FROM retail_sample_data.fscj_ich_banking
+            FROM fscj_ich_banking
             WHERE
                 interaction_type IN ('ACCOUNT_BOOKED_OFFLINE','ACCOUNT_BOOKED_ONLINE','CLICK','REFERRAL','BROWSE')
                 AND product_category <> '-1'
@@ -184,7 +184,7 @@ SELECT * FROM nPath (
 	    SELECT customer_identifier, interaction_timestamp, interaction_type, product_category, interaction_type || '_' || product_category AS event, 
                 marketing_category, marketing_description, marketing_placement, sales_channel, 
                 conversion_sales, conversion_cost, conversion_margin
-            FROM retail_sample_data.fscj_ich_banking
+            FROM fscj_ich_banking
             WHERE
                 product_category <> '-1'
                 AND interaction_type || '_' || product_category <> 'STARTS_APPLICATION_WEALTH MANAGEMENT'

--- a/VantageCloudLakeUseCases/content/KneeReplacement/README.md
+++ b/VantageCloudLakeUseCases/content/KneeReplacement/README.md
@@ -127,7 +127,7 @@ Examples include:
 ## Dataset
 ***
 
-The <b>retail_sample_data.knee_replacement</b> dataset has 289,839 rows, each representing a procedure that a patient has undertaken. The dataset is denormalized so some patient information is repeated in each row:
+The <b>knee_replacement</b> dataset has 289,839 rows, each representing a procedure that a patient has undertaken. The dataset is denormalized so some patient information is repeated in each row:
 
 - `memberid`: unique patient identifier
 - `proccode`: procedure identifier

--- a/VantageCloudLakeUseCases/content/SalesOffload/README.md
+++ b/VantageCloudLakeUseCases/content/SalesOffload/README.md
@@ -31,13 +31,13 @@ Here is our current sales data. Lets grab some sample rows, we can see in this e
 
 ```sql
 SELECT TOP 10 * 
-FROM retail_sample_data.so_sales_fact
+FROM so_sales_fact
 ```
 
 
 ```sql
 SELECT sales_date, sum(sales_quantity) as total 
-FROM retail_sample_data.so_sales_fact
+FROM so_sales_fact
 GROUP BY sales_date
 ORDER BY sales_date ASC
 ```
@@ -48,7 +48,7 @@ ORDER BY sales_date ASC
 
 
 ```sql
-SELECT MIN(sales_date) AS min_date, MAX(sales_date) AS max_date FROM retail_sample_data.so_sales_fact
+SELECT MIN(sales_date) AS min_date, MAX(sales_date) AS max_date FROM so_sales_fact
 ```
 
 How many records do we have in the data warehouse (2019 data)?
@@ -56,7 +56,7 @@ How many records do we have in the data warehouse (2019 data)?
 
 ```sql
 SELECT COUNT(*)
-FROM retail_sample_data.so_sales_fact
+FROM so_sales_fact
 ```
 
 
@@ -111,7 +111,7 @@ Create a foreign table and a view in Vantage to allow business analysts and othe
 
 
 ```sql
-CREATE FOREIGN TABLE retail_sample_data.sales_fact_offload
+CREATE FOREIGN TABLE sales_fact_offload
 , EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS
 USING
        (
@@ -127,7 +127,7 @@ Lets take a look at some of the rows that are in the offloaded files.
 
 ```sql
 SELECT TOP 10 *
-FROM retail_sample_data.sales_fact_offload;
+FROM sales_fact_offload;
 ```
 
 How much data do we have out there?
@@ -135,7 +135,7 @@ How much data do we have out there?
 
 ```sql
 SELECT COUNT(*)
-FROM retail_sample_data.sales_fact_offload;
+FROM sales_fact_offload;
 ```
 
 
@@ -143,7 +143,7 @@ Ok, we are close! We want the data to look like a native table. So let's put a v
 
 
 ```sql
-REPLACE VIEW retail_sample_data.sales_fact_offload_v as (  
+REPLACE VIEW sales_fact_offload_v as (  
 SELECT 
     sales_date,
     customer_id,
@@ -152,7 +152,7 @@ SELECT
     product_id,
     sales_quantity,
     discount_amount
-FROM retail_sample_data.sales_fact_offload);
+FROM sales_fact_offload);
 ```
 
 
@@ -161,7 +161,7 @@ Now we can query the data like any other table in Teradata Vantage, but the data
 
 ```sql
 SELECT TOP 10 *
-FROM retail_sample_data.sales_fact_offload_v;
+FROM sales_fact_offload_v;
 ```
 
 That looks nice! Now our users can access all the historical data we have in the object store!
@@ -176,11 +176,11 @@ We have a lot of data in S3! Let's optimize the foreign table so that we minimiz
 
 
 ```sql
-DROP TABLE retail_sample_data.sales_fact_offload;
+DROP TABLE sales_fact_offload;
 ```
 
 ```sql
-CREATE FOREIGN TABLE retail_sample_data.sales_fact_offload
+CREATE FOREIGN TABLE sales_fact_offload
 , EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS
 USING
        (
@@ -198,7 +198,7 @@ Now let's re-create our user-friendly view that allows for this path filtering..
 
 
 ```sql
-REPLACE VIEW retail_sample_data.sales_fact_offload_v as (  
+REPLACE VIEW sales_fact_offload_v as (  
 SELECT 
     CAST($path.$year AS CHAR(4)) sales_year,
     CAST($path.$month AS CHAR(2)) sales_month,
@@ -209,13 +209,13 @@ SELECT
     product_id,
     sales_quantity,
     discount_amount
-FROM retail_sample_data.sales_fact_offload);
+FROM sales_fact_offload);
 ```
 
 
 ```sql
 SELECT TOP 10 *
-FROM retail_sample_data.sales_fact_offload_v
+FROM sales_fact_offload_v
 WHERE sales_year = '2010'
 AND sales_month = '9';
 ```
@@ -227,7 +227,7 @@ Let's take a look at what store 6 did for sales back in August 2012:
 
 ```sql
 SELECT store_id, SUM(sales_quantity)
-FROM retail_sample_data.sales_fact_offload_v
+FROM sales_fact_offload_v
 WHERE store_id = 6
 AND sales_year = '2012'
 AND sales_month = '8'
@@ -239,7 +239,7 @@ Let's join the historical data with the current data so we can see the full pict
 
 
 ```sql
-REPLACE VIEW retail_sample_data.sales_fact_all as (
+REPLACE VIEW sales_fact_all as (
 SELECT sales_date,
     customer_id,
     store_id,
@@ -247,7 +247,7 @@ SELECT sales_date,
     product_id,
     sales_quantity,
     discount_amount
-    FROM retail_sample_data.so_sales_fact
+    FROM so_sales_fact
     UNION ALL
 SELECT 
     sales_date,
@@ -257,7 +257,7 @@ SELECT
     product_id,
     sales_quantity,
     discount_amount
-FROM retail_sample_data.sales_fact_offload_v);
+FROM sales_fact_offload_v);
 ```
 
 
@@ -266,7 +266,7 @@ Final thing we will do is re-run our sales over time report, code is unchanged f
 
 ```sql
 SELECT sales_date, sum(sales_quantity) as total 
-FROM retail_sample_data.sales_fact_all
+FROM sales_fact_all
 GROUP BY sales_date
 ORDER BY sales_date ASC;
 ```
@@ -284,17 +284,17 @@ Drop the objects we created in our own database schema.
 
 
 ```sql
-DROP VIEW retail_sample_data.sales_fact_all;
+DROP VIEW sales_fact_all;
 ```
 
 
 ```sql
-DROP VIEW retail_sample_data.sales_fact_offload_v;
+DROP VIEW sales_fact_offload_v;
 ```
 
 
 ```sql
-DROP TABLE retail_sample_data.sales_fact_offload;
+DROP TABLE sales_fact_offload;
 ```
 
 ## Dataset

--- a/VantageCloudLakeUseCases/content/TimeSeriesAnalysis/README.md
+++ b/VantageCloudLakeUseCases/content/TimeSeriesAnalysis/README.md
@@ -31,14 +31,14 @@ Start by counting the number of rows in the table.
 
 
 ```sql
-select count(*) from retail_sample_data.fp_consumer_complaints;
+select count(*) from fp_consumer_complaints;
 ```
 
 There are just under 1.3 million rows. Not a problem to analyze large datasets using Vantage, let's take a look at a sample of the data.
 
 
 ```sql
-select TOP 100 * from retail_sample_data.fp_consumer_complaints;
+select TOP 100 * from fp_consumer_complaints;
 ```
 
 #### Step 2: Visualizing the Data
@@ -50,7 +50,7 @@ The first column is <b>date_received</b>. This is the date the complaints were r
 
 ```sql
 select date_received, count(complaint_id) as counts
-from retail_sample_data.fp_consumer_complaints
+from fp_consumer_complaints
 where date_received BETWEEN DATE '2017-03-01'
 AND DATE '2019-03-01'
 group by date_received;
@@ -70,7 +70,7 @@ Let's group the data by month and replot the graph above.
 
 ```sql
 select extract(year from date_received) || extract(month from date_received) as month_date, count(complaint_id) as counts
-from retail_sample_data.fp_consumer_complaints
+from fp_consumer_complaints
 group by month_date
 order by month_date;
 ```
@@ -87,7 +87,7 @@ Let's narrow down the two spikes above and see exactly where they are happening.
 
 ```sql
 select date_received, count(complaint_id) as counts
-from retail_sample_data.fp_consumer_complaints
+from fp_consumer_complaints
 where year(date_received) = 2017
 group by date_received
 order by date_received;
@@ -105,7 +105,7 @@ As we look at the peaks, we find that they occurred from January 15th to 21st an
 select date_received,
     month(date_received) as month_date,
     count(complaint_id) as counts
-from retail_sample_data.fp_consumer_complaints
+from fp_consumer_complaints
 where year(date_received) = 2017 and month_date in (1, 9)
 group by date_received
 having counts >= 1500
@@ -117,7 +117,7 @@ Let's look at some of the issues that were reported during these dates.
 
 ```sql
 select date_received, company, count(company) as counts
-from retail_sample_data.fp_consumer_complaints
+from fp_consumer_complaints
 where date_received in (
     date '2017-01-19',
     date '2017-01-20',
@@ -144,7 +144,7 @@ Let's now look at the top issues for Navient Solutions and Equifax during those 
 ```sql
 -- analyze top issues reported agains Navient Soultions on 2017-01-19 and 2017-01-20
 select company, product, issue, count(issue) as counts
-from retail_sample_data.fp_consumer_complaints
+from fp_consumer_complaints
 where date_received in (
     date '2017-01-19',
     date '2017-01-20') and
@@ -163,7 +163,7 @@ select
     product,
     issue,
     count(issue) as counts
-from retail_sample_data.fp_consumer_complaints
+from fp_consumer_complaints
 where date_received in (
     date '2017-09-08',
     date '2017-09-09',
@@ -180,7 +180,7 @@ Here we can also confirm our hypothesis. The top issues talk about improper use 
 
 The Consumer Complaints Database has complaints data that was received by the Consumer Financial Protection Bureau (CFPB) on financial products and services, which include but are not limited to bank accounts, credit cards, credit reporting, debt collection, money transfers, mortgages, student loans and other types of consumer credit. The dataset is refreshed daily and contains information on the provider, the complaint, date, ZIP code and more. More information about the dataset can be found in the Consumer section of the <a href="data.gov">Data.gov</a> website.
 
-The <b>retail_sample_data.fp_consumer_complaints</b> dataset has 1,273,782 rows, each representing a unique consumer complaint, and 18 columns, representing the following features:
+The <b>fp_consumer_complaints</b> dataset has 1,273,782 rows, each representing a unique consumer complaint, and 18 columns, representing the following features:
 
 - `date_received`: date that CFPB received the complaint
 - `product`: type of product the consumer identified in the complaint

--- a/VantageCloudLakeUseCases/content/VantagePath/README.md
+++ b/VantageCloudLakeUseCases/content/VantagePath/README.md
@@ -36,7 +36,7 @@ The entire use case takes about 5 minutes to run.
 
 1. Open the <a href="/path-analyzer">Vantage Path</a>.
 2. Select the system connection and authenticate.
-3. Select the following "Event database": retail_sample_data.
+3. Select the following "Event database": 
 4. Select the following "Event table": telco_events.
 5. Select additional parameters or just click "RUN" and analyze the results.
 

--- a/VantageCloudLakeUseCases/content/VantagePath/README.md
+++ b/VantageCloudLakeUseCases/content/VantagePath/README.md
@@ -36,9 +36,8 @@ The entire use case takes about 5 minutes to run.
 
 1. Open the <a href="/path-analyzer">Vantage Path</a>.
 2. Select the system connection and authenticate.
-3. Select the following "Event database": 
-4. Select the following "Event table": telco_events.
-5. Select additional parameters or just click "RUN" and analyze the results.
+3. Select the following "Event table": telco_events.
+4. Select additional parameters or just click "RUN" and analyze the results.
 
 ### Adding Additional Parameters
 

--- a/VantageCloudLakeUseCases/content/nPath/README.md
+++ b/VantageCloudLakeUseCases/content/nPath/README.md
@@ -54,7 +54,7 @@ The Pattern can also be tuned for better focus, for example, to control the numb
 ```sql
 SELECT * FROM npath
 ( 
-   ON retail_sample_data.telco_events
+   ON telco_events
    PARTITION BY entity_id,session_id
    ORDER BY datestamp
    USING 
@@ -86,7 +86,7 @@ We're using a Pattern 'Events leading to BILL DISPUTE, with minimum of 2 and max
 SELECT *
 FROM npath
 (
-   ON (select top 100000 * from retail_sample_data.telco_events)  -- using select to control input records, use full table syntax when pattern finalized
+   ON (select top 100000 * from telco_events)  -- using select to control input records, use full table syntax when pattern finalized
    PARTITION BY entity_id,session_id
    ORDER BY datestamp  
    USING
@@ -125,7 +125,7 @@ By simply changing the Pattern to A.O{1,3} we can now find paths taken after the
 SELECT *
 FROM npath
 (
-   ON (select top 100000 * from retail_sample_data.telco_events)  -- using select to control input records, use full table syntax when pattern finalized
+   ON (select top 100000 * from telco_events)  -- using select to control input records, use full table syntax when pattern finalized
    PARTITION BY entity_id,session_id
    ORDER BY datestamp  
    USING
@@ -166,7 +166,7 @@ Also, notice the nPath PATTERN syntax. Here we're filtering by paths that have a
 SELECT path, count(*) as cnt
 FROM npath
 (
-   ON retail_sample_data.telco_events
+   ON telco_events
    PARTITION BY entity_id,session_id
    ORDER BY datestamp  
    USING
@@ -205,7 +205,7 @@ The function is useful both for sessionization and for detecting web crawler (bo
 select *
 from Sessionize
 (
-    on (select * from retail_sample_data.telco_events where event = 'BILL DISPUTE' and entity_id = '353329')
+    on (select * from telco_events where event = 'BILL DISPUTE' and entity_id = '353329')
     partition by entity_id
     order by datestamp
     using

--- a/VantageCloudLakeUseCases/datasets/BustOutFraud/scripts/acct_bustouts.sql
+++ b/VantageCloudLakeUseCases/datasets/BustOutFraud/scripts/acct_bustouts.sql
@@ -1,6 +1,6 @@
-DROP TABLE retail_sample_data.bof_acct_bustouts ;
+DROP TABLE bof_acct_bustouts ;
 
-CREATE MULTISET FOREIGN TABLE retail_sample_data.bof_acct_bustouts ,FALLBACK ,
+CREATE MULTISET FOREIGN TABLE bof_acct_bustouts ,FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1
      (

--- a/VantageCloudLakeUseCases/datasets/BustOutFraud/scripts/acct_feature.sql
+++ b/VantageCloudLakeUseCases/datasets/BustOutFraud/scripts/acct_feature.sql
@@ -1,5 +1,5 @@
-DROP TABLE retail_sample_data.bof_acct_feature ;
-CREATE MULTISET FOREIGN TABLE retail_sample_data.bof_acct_feature ,FALLBACK ,
+DROP TABLE bof_acct_feature ;
+CREATE MULTISET FOREIGN TABLE bof_acct_feature ,FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1
      (

--- a/VantageCloudLakeUseCases/datasets/BustOutFraud/scripts/acct_predict.sql
+++ b/VantageCloudLakeUseCases/datasets/BustOutFraud/scripts/acct_predict.sql
@@ -1,5 +1,5 @@
-DROP TABLE retail_sample_data.bof_acct_predict ;
-CREATE MULTISET FOREIGN TABLE retail_sample_data.bof_acct_predict ,FALLBACK ,
+DROP TABLE bof_acct_predict ;
+CREATE MULTISET FOREIGN TABLE bof_acct_predict ,FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1
      (

--- a/VantageCloudLakeUseCases/datasets/BustOutFraud/scripts/acct_statement.sql
+++ b/VantageCloudLakeUseCases/datasets/BustOutFraud/scripts/acct_statement.sql
@@ -1,5 +1,5 @@
-DROP TABLE retail_sample_data.bof_acct_statement ;
-CREATE MULTISET FOREIGN TABLE retail_sample_data.bof_acct_statement ,FALLBACK ,
+DROP TABLE bof_acct_statement ;
+CREATE MULTISET FOREIGN TABLE bof_acct_statement ,FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1
      (

--- a/VantageCloudLakeUseCases/datasets/BustOutFraud/scripts/all_dates.sql
+++ b/VantageCloudLakeUseCases/datasets/BustOutFraud/scripts/all_dates.sql
@@ -1,5 +1,5 @@
-DROP TABLE retail_sample_data.bof_all_dates ;
-CREATE MULTISET FOREIGN TABLE retail_sample_data.bof_all_dates ,FALLBACK ,
+DROP TABLE bof_all_dates ;
+CREATE MULTISET FOREIGN TABLE bof_all_dates ,FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1
      (

--- a/VantageCloudLakeUseCases/datasets/BustOutFraud/scripts/credit_bureau_data.sql
+++ b/VantageCloudLakeUseCases/datasets/BustOutFraud/scripts/credit_bureau_data.sql
@@ -1,5 +1,5 @@
-DROP TABLE retail_sample_data.credit_bureau_data ;
-CREATE MULTISET FOREIGN TABLE retail_sample_data.credit_bureau_data ,FALLBACK ,
+DROP TABLE credit_bureau_data ;
+CREATE MULTISET FOREIGN TABLE credit_bureau_data ,FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1
      (

--- a/VantageCloudLakeUseCases/datasets/BustOutFraud/scripts/merchant.sql
+++ b/VantageCloudLakeUseCases/datasets/BustOutFraud/scripts/merchant.sql
@@ -1,5 +1,5 @@
-DROP TABLE retail_sample_data.bof_merchant ;
-CREATE MULTISET FOREIGN TABLE retail_sample_data.bof_merchant ,FALLBACK ,
+DROP TABLE bof_merchant ;
+CREATE MULTISET FOREIGN TABLE bof_merchant ,FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1
      (

--- a/VantageCloudLakeUseCases/datasets/BustOutFraud/scripts/party.sql
+++ b/VantageCloudLakeUseCases/datasets/BustOutFraud/scripts/party.sql
@@ -1,5 +1,5 @@
-DROP TABLE retail_sample_data.bof_party ;
-CREATE MULTISET FOREIGN TABLE retail_sample_data.bof_party ,FALLBACK ,
+DROP TABLE bof_party ;
+CREATE MULTISET FOREIGN TABLE bof_party ,FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1
      (

--- a/VantageCloudLakeUseCases/datasets/BustOutFraud/scripts/party_acct.sql
+++ b/VantageCloudLakeUseCases/datasets/BustOutFraud/scripts/party_acct.sql
@@ -1,5 +1,5 @@
-DROP TABLE retail_sample_data.bof_party_acct ;
-CREATE MULTISET FOREIGN TABLE retail_sample_data.bof_party_acct ,FALLBACK ,
+DROP TABLE bof_party_acct ;
+CREATE MULTISET FOREIGN TABLE bof_party_acct ,FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1
      (

--- a/VantageCloudLakeUseCases/datasets/BustOutFraud/scripts/trans_feature.sql
+++ b/VantageCloudLakeUseCases/datasets/BustOutFraud/scripts/trans_feature.sql
@@ -1,5 +1,5 @@
-DROP TABLE retail_sample_data.bof_trans_feature ;
-CREATE MULTISET FOREIGN TABLE retail_sample_data.bof_trans_feature ,FALLBACK ,
+DROP TABLE bof_trans_feature ;
+CREATE MULTISET FOREIGN TABLE bof_trans_feature ,FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1
      (

--- a/VantageCloudLakeUseCases/datasets/BustOutFraud/scripts/trans_feature_day_derived.sql
+++ b/VantageCloudLakeUseCases/datasets/BustOutFraud/scripts/trans_feature_day_derived.sql
@@ -1,5 +1,5 @@
-DROP TABLE retail_sample_data.bof_trans_feature_day_derived ;
-CREATE MULTISET FOREIGN TABLE retail_sample_data.bof_trans_feature_day_derived ,FALLBACK ,
+DROP TABLE bof_trans_feature_day_derived ;
+CREATE MULTISET FOREIGN TABLE bof_trans_feature_day_derived ,FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1
      (

--- a/VantageCloudLakeUseCases/datasets/BustOutFraud/scripts/trans_feature_month_derived.sql
+++ b/VantageCloudLakeUseCases/datasets/BustOutFraud/scripts/trans_feature_month_derived.sql
@@ -1,5 +1,5 @@
-DROP TABLE retail_sample_data.bof_trans_feature_month_derived ;
-CREATE MULTISET FOREIGN TABLE retail_sample_data.bof_trans_feature_month_derived ,FALLBACK ,
+DROP TABLE bof_trans_feature_month_derived ;
+CREATE MULTISET FOREIGN TABLE bof_trans_feature_month_derived ,FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1
      (

--- a/VantageCloudLakeUseCases/datasets/BustOutFraud/scripts/transaction_daily_counts.sql
+++ b/VantageCloudLakeUseCases/datasets/BustOutFraud/scripts/transaction_daily_counts.sql
@@ -1,5 +1,5 @@
-DROP TABLE retail_sample_data.bof_transaction_daily_counts ;
-CREATE MULTISET FOREIGN TABLE retail_sample_data.bof_transaction_daily_counts ,FALLBACK ,
+DROP TABLE bof_transaction_daily_counts ;
+CREATE MULTISET FOREIGN TABLE bof_transaction_daily_counts ,FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1
      (

--- a/VantageCloudLakeUseCases/datasets/BustOutFraud/scripts/transaction_detail.sql
+++ b/VantageCloudLakeUseCases/datasets/BustOutFraud/scripts/transaction_detail.sql
@@ -1,5 +1,5 @@
-DROP TABLE retail_sample_data.bof_transaction_detail ;
-CREATE MULTISET FOREIGN TABLE retail_sample_data.bof_transaction_detail ,FALLBACK ,
+DROP TABLE bof_transaction_detail ;
+CREATE MULTISET FOREIGN TABLE bof_transaction_detail ,FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1
      (

--- a/VantageCloudLakeUseCases/datasets/BustOutFraud/scripts/transaction_detail_staging.sql
+++ b/VantageCloudLakeUseCases/datasets/BustOutFraud/scripts/transaction_detail_staging.sql
@@ -1,5 +1,5 @@
-DROP TABLE retail_sample_data.bof_transaction_detail_staging ;
-CREATE MULTISET FOREIGN TABLE retail_sample_data.bof_transaction_detail_staging ,FALLBACK ,
+DROP TABLE bof_transaction_detail_staging ;
+CREATE MULTISET FOREIGN TABLE bof_transaction_detail_staging ,FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1
      (

--- a/VantageCloudLakeUseCases/datasets/Demo/scripts/demo_equip_events.sql
+++ b/VantageCloudLakeUseCases/datasets/Demo/scripts/demo_equip_events.sql
@@ -1,5 +1,5 @@
-DROP TABLE retail_sample_data.demo_equip_events ;
-CREATE MULTISET FOREIGN TABLE retail_sample_data.demo_equip_events ,FALLBACK ,
+DROP TABLE demo_equip_events ;
+CREATE MULTISET FOREIGN TABLE demo_equip_events ,FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1
 	(

--- a/VantageCloudLakeUseCases/datasets/Demo/scripts/demo_equip_logs.sql
+++ b/VantageCloudLakeUseCases/datasets/Demo/scripts/demo_equip_logs.sql
@@ -1,5 +1,5 @@
-DROP TABLE retail_sample_data.demo_equip_logs ;
-CREATE MULTISET FOREIGN TABLE retail_sample_data.demo_equip_logs ,FALLBACK ,
+DROP TABLE demo_equip_logs ;
+CREATE MULTISET FOREIGN TABLE demo_equip_logs ,FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1
 (

--- a/VantageCloudLakeUseCases/datasets/Demo/scripts/demo_equip_testing.sql
+++ b/VantageCloudLakeUseCases/datasets/Demo/scripts/demo_equip_testing.sql
@@ -1,5 +1,5 @@
-DROP TABLE retail_sample_data.demo_equip_testing ;
-CREATE MULTISET FOREIGN TABLE retail_sample_data.demo_equip_testing ,FALLBACK ,
+DROP TABLE demo_equip_testing ;
+CREATE MULTISET FOREIGN TABLE demo_equip_testing ,FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1
 (

--- a/VantageCloudLakeUseCases/datasets/Demo/scripts/demo_equip_training.sql
+++ b/VantageCloudLakeUseCases/datasets/Demo/scripts/demo_equip_training.sql
@@ -1,5 +1,5 @@
-DROP TABLE retail_sample_data.demo_equip_training ;
-CREATE MULTISET FOREIGN TABLE retail_sample_data.demo_equip_training ,FALLBACK ,
+DROP TABLE demo_equip_training ;
+CREATE MULTISET FOREIGN TABLE demo_equip_training ,FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1
 (

--- a/VantageCloudLakeUseCases/datasets/Demo/scripts/telco_testing.sql
+++ b/VantageCloudLakeUseCases/datasets/Demo/scripts/telco_testing.sql
@@ -1,5 +1,5 @@
-DROP TABLE retail_sample_data.demo_telco_testing ;
-CREATE MULTISET FOREIGN TABLE retail_sample_data.demo_telco_testing ,FALLBACK ,
+DROP TABLE demo_telco_testing ;
+CREATE MULTISET FOREIGN TABLE demo_telco_testing ,FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1
 ( 

--- a/VantageCloudLakeUseCases/datasets/Demo/scripts/telco_training.sql
+++ b/VantageCloudLakeUseCases/datasets/Demo/scripts/telco_training.sql
@@ -1,5 +1,5 @@
-DROP TABLE retail_sample_data.demo_telco_training ;
-CREATE MULTISET FOREIGN TABLE retail_sample_data.demo_telco_training ,FALLBACK ,
+DROP TABLE demo_telco_training ;
+CREATE MULTISET FOREIGN TABLE demo_telco_training ,FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1
 ( 

--- a/VantageCloudLakeUseCases/datasets/Demo/scripts/titan_mortgage_events.sql
+++ b/VantageCloudLakeUseCases/datasets/Demo/scripts/titan_mortgage_events.sql
@@ -1,5 +1,5 @@
-DROP TABLE retail_sample_data.demo_titan_mortgage_events ;
-CREATE MULTISET FOREIGN TABLE retail_sample_data.demo_titan_mortgage_events ,FALLBACK ,
+DROP TABLE demo_titan_mortgage_events ;
+CREATE MULTISET FOREIGN TABLE demo_titan_mortgage_events ,FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1
 ( 

--- a/VantageCloudLakeUseCases/datasets/Demo/scripts/titan_telco_events.sql
+++ b/VantageCloudLakeUseCases/datasets/Demo/scripts/titan_telco_events.sql
@@ -1,5 +1,5 @@
-DROP TABLE retail_sample_data.demo_titan_telco_events ;
-CREATE MULTISET FOREIGN TABLE retail_sample_data.demo_titan_telco_events ,FALLBACK ,
+DROP TABLE demo_titan_telco_events ;
+CREATE MULTISET FOREIGN TABLE demo_titan_telco_events ,FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1 
 	( 

--- a/VantageCloudLakeUseCases/datasets/EVCarBattery/scripts/badbatts.sql
+++ b/VantageCloudLakeUseCases/datasets/EVCarBattery/scripts/badbatts.sql
@@ -1,6 +1,6 @@
-DROP TABLE retail_sample_data.ev_badbatts ;
+DROP TABLE ev_badbatts ;
 
-CREATE MULTISET FOREIGN TABLE retail_sample_data.ev_badbatts , FALLBACK ,
+CREATE MULTISET FOREIGN TABLE ev_badbatts , FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1
      (

--- a/VantageCloudLakeUseCases/datasets/EVCarBattery/scripts/batteries_nos.sql
+++ b/VantageCloudLakeUseCases/datasets/EVCarBattery/scripts/batteries_nos.sql
@@ -1,18 +1,18 @@
-DROP TABLE retail_sample_data.obd_nos;
+DROP TABLE obd_nos;
 
-CREATE FOREIGN TABLE retail_sample_data.obd_nos, FALLBACK,
+CREATE FOREIGN TABLE obd_nos, FALLBACK,
 EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS
 (
 LOCATION VARCHAR(2048) CHARACTER SET UNICODE CASESPECIFIC , Payload JSON INLINE LENGTH 32000 CHARACTER SET UNICODE )
 USING(LOCATION('/S3/s3.amazonaws.com/trial-datasets/EVCarBattery/') );
 
 
-REPLACE VIEW retail_sample_data.nos_test_reports_v AS
+REPLACE VIEW nos_test_reports_v AS
 (SELECT vin, part_no, lot_no, CAST(test_report AS JSON) test_report
 FROM TD_JSONSHRED(
     ON (
                 SELECT payload.vin as vin, payload
-                FROM retail_sample_data.obd_nos)
+                FROM obd_nos)
             USING
             ROWEXPR('parts')
             COLEXPR('part_no', 'lot_no', 'test_report')

--- a/VantageCloudLakeUseCases/datasets/EVCarBattery/scripts/bom.sql
+++ b/VantageCloudLakeUseCases/datasets/EVCarBattery/scripts/bom.sql
@@ -1,6 +1,6 @@
-DROP TABLE retail_sample_data.ev_bom ;
+DROP TABLE ev_bom ;
 
-CREATE MULTISET FOREIGN TABLE retail_sample_data.ev_bom , FALLBACK ,
+CREATE MULTISET FOREIGN TABLE ev_bom , FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1
      (

--- a/VantageCloudLakeUseCases/datasets/EVCarBattery/scripts/customers.sql
+++ b/VantageCloudLakeUseCases/datasets/EVCarBattery/scripts/customers.sql
@@ -1,6 +1,6 @@
-DROP TABLE retail_sample_data.ev_customers ;
+DROP TABLE ev_customers ;
 
-CREATE MULTISET FOREIGN TABLE retail_sample_data.ev_customers , FALLBACK ,
+CREATE MULTISET FOREIGN TABLE ev_customers , FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1
      (

--- a/VantageCloudLakeUseCases/datasets/EVCarBattery/scripts/dealers.sql
+++ b/VantageCloudLakeUseCases/datasets/EVCarBattery/scripts/dealers.sql
@@ -1,6 +1,6 @@
-DROP TABLE retail_sample_data.ev_dealers ;
+DROP TABLE ev_dealers ;
 
-CREATE MULTISET FOREIGN TABLE retail_sample_data.ev_dealers , FALLBACK ,
+CREATE MULTISET FOREIGN TABLE ev_dealers , FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1
      (

--- a/VantageCloudLakeUseCases/datasets/EVCarBattery/scripts/dtc.sql
+++ b/VantageCloudLakeUseCases/datasets/EVCarBattery/scripts/dtc.sql
@@ -1,6 +1,6 @@
-DROP TABLE retail_sample_data.ev_dtc ;
+DROP TABLE ev_dtc ;
 
-CREATE MULTISET FOREIGN TABLE retail_sample_data.ev_dtc , FALLBACK ,
+CREATE MULTISET FOREIGN TABLE ev_dtc , FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1
      (

--- a/VantageCloudLakeUseCases/datasets/EVCarBattery/scripts/freeze_frames.sql
+++ b/VantageCloudLakeUseCases/datasets/EVCarBattery/scripts/freeze_frames.sql
@@ -1,4 +1,4 @@
-CREATE SET TABLE retail_sample_data.ev_freeze_frames
+CREATE SET TABLE ev_freeze_frames
      (
       id INTEGER NOT NULL, 
       data JSON(2000) CHARACTER SET LATIN, 

--- a/VantageCloudLakeUseCases/datasets/EVCarBattery/scripts/mfg_plants.sql
+++ b/VantageCloudLakeUseCases/datasets/EVCarBattery/scripts/mfg_plants.sql
@@ -1,6 +1,6 @@
-DROP TABLE retail_sample_data.ev_mfg_plants ;
+DROP TABLE ev_mfg_plants ;
 
-CREATE MULTISET FOREIGN TABLE retail_sample_data.ev_mfg_plants , FALLBACK ,
+CREATE MULTISET FOREIGN TABLE ev_mfg_plants , FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1
      (

--- a/VantageCloudLakeUseCases/datasets/EVCarBattery/scripts/parts.sql
+++ b/VantageCloudLakeUseCases/datasets/EVCarBattery/scripts/parts.sql
@@ -1,6 +1,6 @@
-DROP TABLE retail_sample_data.ev_parts ;
+DROP TABLE ev_parts ;
 
-CREATE MULTISET FOREIGN TABLE retail_sample_data.ev_parts , FALLBACK ,
+CREATE MULTISET FOREIGN TABLE ev_parts , FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1
      (

--- a/VantageCloudLakeUseCases/datasets/EVCarBattery/scripts/service_visits.sql
+++ b/VantageCloudLakeUseCases/datasets/EVCarBattery/scripts/service_visits.sql
@@ -1,6 +1,6 @@
-DROP TABLE retail_sample_data.ev_service_visits ;
+DROP TABLE ev_service_visits ;
 
-CREATE MULTISET FOREIGN TABLE retail_sample_data.ev_service_visits , FALLBACK ,
+CREATE MULTISET FOREIGN TABLE ev_service_visits , FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1
      (

--- a/VantageCloudLakeUseCases/datasets/EVCarBattery/scripts/vehicles.sql
+++ b/VantageCloudLakeUseCases/datasets/EVCarBattery/scripts/vehicles.sql
@@ -1,6 +1,6 @@
-DROP TABLE retail_sample_data.ev_vehicles ;
+DROP TABLE ev_vehicles ;
 
-CREATE MULTISET FOREIGN TABLE retail_sample_data.ev_vehicles , FALLBACK ,
+CREATE MULTISET FOREIGN TABLE ev_vehicles , FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1
      (

--- a/VantageCloudLakeUseCases/datasets/FSCustomerJourney/scripts/complaints.sql
+++ b/VantageCloudLakeUseCases/datasets/FSCustomerJourney/scripts/complaints.sql
@@ -1,5 +1,5 @@
-DROP TABLE retail_sample_data.fscj_complaints ;
-CREATE MULTISET FOREIGN TABLE retail_sample_data.fscj_complaints ,FALLBACK ,
+DROP TABLE fscj_complaints ;
+CREATE MULTISET FOREIGN TABLE fscj_complaints ,FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1
      (

--- a/VantageCloudLakeUseCases/datasets/FSCustomerJourney/scripts/customers.sql
+++ b/VantageCloudLakeUseCases/datasets/FSCustomerJourney/scripts/customers.sql
@@ -1,5 +1,5 @@
-DROP TABLE retail_sample_data.fscj_customers ;
-CREATE MULTISET FOREIGN TABLE retail_sample_data.fscj_customers ,FALLBACK ,
+DROP TABLE fscj_customers ;
+CREATE MULTISET FOREIGN TABLE fscj_customers ,FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1
      (

--- a/VantageCloudLakeUseCases/datasets/FSCustomerJourney/scripts/ich_banking.sql
+++ b/VantageCloudLakeUseCases/datasets/FSCustomerJourney/scripts/ich_banking.sql
@@ -1,5 +1,5 @@
-DROP TABLE retail_sample_data.fscj_ich_banking ;
-CREATE MULTISET FOREIGN TABLE retail_sample_data.fscj_ich_banking ,FALLBACK ,
+DROP TABLE fscj_ich_banking ;
+CREATE MULTISET FOREIGN TABLE fscj_ich_banking ,FALLBACK ,
     EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
 	MAP = TD_MAP1  
 	( 

--- a/VantageCloudLakeUseCases/datasets/FinancialProtection/scripts/consumer_complaints.sql
+++ b/VantageCloudLakeUseCases/datasets/FinancialProtection/scripts/consumer_complaints.sql
@@ -1,5 +1,5 @@
-DROP TABLE retail_sample_data.fp_consumer_complaints ;
-CREATE MULTISET FOREIGN TABLE retail_sample_data.fp_consumer_complaints ,FALLBACK ,
+DROP TABLE fp_consumer_complaints ;
+CREATE MULTISET FOREIGN TABLE fp_consumer_complaints ,FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1
      (

--- a/VantageCloudLakeUseCases/datasets/IdentityMatch/scripts/ac_customer_external_data.sql
+++ b/VantageCloudLakeUseCases/datasets/IdentityMatch/scripts/ac_customer_external_data.sql
@@ -1,5 +1,5 @@
-DROP TABLE retail_sample_data.im_ac_customer_external_data ;
-CREATE MULTISET FOREIGN TABLE retail_sample_data.im_ac_customer_external_data ,FALLBACK ,
+DROP TABLE im_ac_customer_external_data ;
+CREATE MULTISET FOREIGN TABLE im_ac_customer_external_data ,FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1
      (

--- a/VantageCloudLakeUseCases/datasets/IdentityMatch/scripts/ref_golden_cust.sql
+++ b/VantageCloudLakeUseCases/datasets/IdentityMatch/scripts/ref_golden_cust.sql
@@ -1,5 +1,5 @@
-DROP TABLE retail_sample_data.im_ref_golden_cust ;
-CREATE MULTISET FOREIGN TABLE retail_sample_data.im_ref_golden_cust ,FALLBACK ,
+DROP TABLE im_ref_golden_cust ;
+CREATE MULTISET FOREIGN TABLE im_ref_golden_cust ,FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1
      (

--- a/VantageCloudLakeUseCases/datasets/IndoorSensor/scripts/connectivity.sql
+++ b/VantageCloudLakeUseCases/datasets/IndoorSensor/scripts/connectivity.sql
@@ -1,5 +1,5 @@
-DROP TABLE retail_sample_data.is_connectivity ;
-CREATE MULTISET FOREIGN TABLE retail_sample_data.is_connectivity ,FALLBACK ,
+DROP TABLE is_connectivity ;
+CREATE MULTISET FOREIGN TABLE is_connectivity ,FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1
      (

--- a/VantageCloudLakeUseCases/datasets/IndoorSensor/scripts/sensor_locations.sql
+++ b/VantageCloudLakeUseCases/datasets/IndoorSensor/scripts/sensor_locations.sql
@@ -1,5 +1,5 @@
-DROP TABLE retail_sample_data.is_sensor_locations ;
-CREATE MULTISET FOREIGN TABLE retail_sample_data.is_sensor_locations ,FALLBACK ,
+DROP TABLE is_sensor_locations ;
+CREATE MULTISET FOREIGN TABLE is_sensor_locations ,FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1
      (

--- a/VantageCloudLakeUseCases/datasets/KneeReplacement/scripts/knee_replacement.sql
+++ b/VantageCloudLakeUseCases/datasets/KneeReplacement/scripts/knee_replacement.sql
@@ -1,5 +1,5 @@
-DROP TABLE retail_sample_data.knee_replacement ;
-CREATE MULTISET FOREIGN TABLE retail_sample_data.knee_replacement ,FALLBACK ,
+DROP TABLE knee_replacement ;
+CREATE MULTISET FOREIGN TABLE knee_replacement ,FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1
      (

--- a/VantageCloudLakeUseCases/datasets/KneeReplacement/scripts/path_views.sql
+++ b/VantageCloudLakeUseCases/datasets/KneeReplacement/scripts/path_views.sql
@@ -1,5 +1,5 @@
 -- Views for the Path Analyzer
-CREATE VIEW retail_sample_data.knee_replacement_events AS
+CREATE VIEW knee_replacement_events AS
 SELECT memberid as entity_id, tstamp AS datestamp, shortdesc as event,
 memberid, proccode, diagcode, shortdesc, amount, tstamp, firstname, lastname, email, state        
-FROM retail_sample_data.knee_replacement;
+FROM knee_replacement;

--- a/VantageCloudLakeUseCases/datasets/SalesOffload/scripts/sales_fact.sql
+++ b/VantageCloudLakeUseCases/datasets/SalesOffload/scripts/sales_fact.sql
@@ -1,6 +1,6 @@
-DROP TABLE retail_sample_data.so_sales_fact ;
+DROP TABLE so_sales_fact ;
 
-CREATE MULTISET FOREIGN TABLE retail_sample_data.so_sales_fact ,FALLBACK ,
+CREATE MULTISET FOREIGN TABLE so_sales_fact ,FALLBACK ,
     EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
     MAP = TD_MAP1
     (

--- a/VantageCloudLakeUseCases/datasets/Telco/scripts/events.sql
+++ b/VantageCloudLakeUseCases/datasets/Telco/scripts/events.sql
@@ -1,6 +1,6 @@
-DROP TABLE retail_sample_data.telco_events ;
+DROP TABLE telco_events ;
 
-CREATE MULTISET FOREIGN TABLE retail_sample_data.telco_events , FALLBACK ,
+CREATE MULTISET FOREIGN TABLE telco_events , FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1
      (

--- a/VantageCloudLakeUseCases/datasets/Telco/scripts/testing.sql
+++ b/VantageCloudLakeUseCases/datasets/Telco/scripts/testing.sql
@@ -1,6 +1,6 @@
-DROP TABLE retail_sample_data.telco_testing ;
+DROP TABLE telco_testing ;
 
-CREATE MULTISET FOREIGN TABLE retail_sample_data.telco_testing , FALLBACK ,
+CREATE MULTISET FOREIGN TABLE telco_testing , FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1
      (

--- a/VantageCloudLakeUseCases/datasets/Telco/scripts/training.sql
+++ b/VantageCloudLakeUseCases/datasets/Telco/scripts/training.sql
@@ -1,6 +1,6 @@
-DROP TABLE retail_sample_data.telco_training ;
+DROP TABLE telco_training ;
 
-CREATE MULTISET FOREIGN TABLE retail_sample_data.telco_training , FALLBACK ,
+CREATE MULTISET FOREIGN TABLE telco_training , FALLBACK ,
      EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
      MAP = TD_MAP1
      (

--- a/VantageCloudLakeUseCases/datasets/TelcoChurn/scripts/csi_telco_data.sql
+++ b/VantageCloudLakeUseCases/datasets/TelcoChurn/scripts/csi_telco_data.sql
@@ -1,5 +1,5 @@
-DROP TABLE retail_sample_data.tc_csi_telco_data ;
-CREATE MULTISET FOREIGN TABLE retail_sample_data.tc_csi_telco_data ,FALLBACK ,
+DROP TABLE tc_csi_telco_data ;
+CREATE MULTISET FOREIGN TABLE tc_csi_telco_data ,FALLBACK ,
     EXTERNAL SECURITY retail_sample_data.DEMO_AUTH_NOS ,
     MAP = TD_MAP1
     (


### PR DESCRIPTION
VDT-2737 There is a production issue which causes an error with the database, so it has to use the user's database, and "retail_sample_data." must be removed from the scripts.